### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Webpack
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Meeranmk/portfolio/security/code-scanning/1](https://github.com/Meeranmk/portfolio/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The minimal required permission for a typical build workflow is `contents: read`, which allows the workflow to read repository contents but not write to them or perform other privileged actions. This block can be added at the top level (applies to all jobs) or at the job level (applies only to the specified job). Since there is only one job in this workflow, adding it at the top level is simplest and most maintainable. No additional methods, imports, or definitions are needed—just a YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
