### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,4 +1,6 @@
 name: SonarCloud Analysis
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Meeranmk/portfolio/security/code-scanning/2](https://github.com/Meeranmk/portfolio/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow. The best way is to add it at the root level (just below the `name:` and before `on:`), so it applies to all jobs unless overridden. For SonarCloud analysis, the workflow typically only needs read access to repository contents, so the minimal permissions block should be `contents: read`. If you know the workflow needs additional permissions (e.g., to update pull requests), you can add them, but the minimal fix is to add `permissions: contents: read` at the root of the workflow file. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
